### PR TITLE
feat: chain call

### DIFF
--- a/.changeset/fair-planes-pay.md
+++ b/.changeset/fair-planes-pay.md
@@ -1,6 +1,6 @@
 ---
-'@vue-macros/chain-call': major
-'@vue-macros/common': minor
+'@vue-macros/chain-call': patch
+'@vue-macros/common': patch
 ---
 
-add package `@vue-macros/chain-call`, add `isVariableNamedOf` in `@vue-macros/common`
+new feature `chainCall`

--- a/.changeset/fair-planes-pay.md
+++ b/.changeset/fair-planes-pay.md
@@ -1,0 +1,6 @@
+---
+'@vue-macros/chain-call': major
+'@vue-macros/common': minor
+---
+
+add package `@vue-macros/chain-call`, add `isVariableNamedOf` in `@vue-macros/common`

--- a/packages/chain-call/macros.d.ts
+++ b/packages/chain-call/macros.d.ts
@@ -1,0 +1,64 @@
+import { type ComponentObjectPropsOptions, type ExtractPropTypes } from 'vue'
+
+// copy from vue-core
+export type Prettify<T> = {
+  [K in keyof T]: T[K]
+} & {}
+
+type NotUndefined<T> = T extends undefined ? never : T
+type InferDefaults<T> = {
+  [K in keyof T]?: InferDefault<T, T[K]>
+}
+type NativeType = null | number | string | boolean | symbol | Function
+type InferDefault<P, T> =
+  | ((props: P) => T & {})
+  | (T extends NativeType ? T : never)
+type PropsWithDefaults<
+  T,
+  Defaults extends InferDefaults<T>,
+  BKeys extends keyof T
+> = Omit<T, keyof Defaults> & {
+  [K in keyof Defaults]-?: K extends keyof T
+    ? Defaults[K] extends undefined
+      ? T[K]
+      : NotUndefined<T[K]>
+    : never
+} & {
+  readonly [K in BKeys]-?: boolean
+}
+type DefineProps<T, BKeys extends keyof T> = Readonly<T> & {
+  readonly [K in BKeys]-?: boolean
+}
+type BooleanKey<T, K extends keyof T = keyof T> = K extends any
+  ? [T[K]] extends [boolean | undefined]
+    ? K
+    : never
+  : never
+
+// end
+
+export type AttachWithDefaults<Props> = Props & {
+  withDefaults: <
+    BKeys extends BooleanKey<Props>,
+    Defaults extends InferDefaults<Props>
+  >(
+    defaults: Defaults
+  ) => Prettify<PropsWithDefaults<Props, Defaults, BKeys>>
+}
+
+export declare function defineProps<PropNames extends string = string>(
+  props: PropNames[]
+): Prettify<
+  AttachWithDefaults<
+    Readonly<{
+      [key in PropNames]?: any
+    }>
+  >
+>
+export declare function defineProps<
+  PP extends ComponentObjectPropsOptions = ComponentObjectPropsOptions
+>(props: PP): Prettify<AttachWithDefaults<Readonly<ExtractPropTypes<PP>>>>
+
+export declare function defineProps<TypeProps>(): AttachWithDefaults<
+  DefineProps<TypeProps, BooleanKey<TypeProps>>
+>

--- a/packages/chain-call/macros.d.ts
+++ b/packages/chain-call/macros.d.ts
@@ -38,12 +38,13 @@ type BooleanKey<T, K extends keyof T = keyof T> = K extends any
 // end
 
 export type AttachWithDefaults<Props> = Props & {
-  withDefaults: <
+  withDefaults(): Props
+  withDefaults<
     BKeys extends BooleanKey<Props>,
     Defaults extends InferDefaults<Props>
   >(
-    defaults: Defaults
-  ) => Prettify<PropsWithDefaults<Props, Defaults, BKeys>>
+    defaults?: Defaults
+  ): Prettify<PropsWithDefaults<Props, Defaults, BKeys>>
 }
 
 export declare function defineProps<PropNames extends string = string>(

--- a/packages/chain-call/package.json
+++ b/packages/chain-call/package.json
@@ -1,0 +1,97 @@
+{
+  "name": "@vue-macros/chain-call",
+  "version": "0.0.0",
+  "packageManager": "pnpm@8.6.0",
+  "description": "chain-call feature from Vue Macros.",
+  "keywords": [
+    "vue-macros",
+    "macros",
+    "vue",
+    "sfc",
+    "setup",
+    "script-setup",
+    "chain-call",
+    "unplugin"
+  ],
+  "license": "MIT",
+  "homepage": "https://github.com/sxzz/vue-macros#readme",
+  "bugs": {
+    "url": "https://github.com/sxzz/vue-macros/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sxzz/vue-macros.git",
+    "directory": "packages/chain-call"
+  },
+  "author": "三咲智子 <sxzz@sxzz.moe>",
+  "files": [
+    "dist"
+  ],
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "index.d.ts",
+  "exports": {
+    ".": {
+      "dev": "./src/index.ts",
+      "types": "./dist/index.d.ts",
+      "require": "./dist/index.js",
+      "import": "./dist/index.mjs"
+    },
+    "./api": {
+      "dev": "./src/api.ts",
+      "types": "./dist/api.d.ts",
+      "require": "./dist/api.js",
+      "import": "./dist/api.mjs"
+    },
+    "./esbuild": {
+      "dev": "./src/esbuild.ts",
+      "types": "./dist/esbuild.d.ts",
+      "require": "./dist/esbuild.js",
+      "import": "./dist/esbuild.mjs"
+    },
+    "./rollup": {
+      "dev": "./src/rollup.ts",
+      "types": "./dist/rollup.d.ts",
+      "require": "./dist/rollup.js",
+      "import": "./dist/rollup.mjs"
+    },
+    "./vite": {
+      "dev": "./src/vite.ts",
+      "types": "./dist/vite.d.ts",
+      "require": "./dist/vite.js",
+      "import": "./dist/vite.mjs"
+    },
+    "./webpack": {
+      "dev": "./src/webpack.ts",
+      "types": "./dist/webpack.d.ts",
+      "require": "./dist/webpack.js",
+      "import": "./dist/webpack.mjs"
+    },
+    "./*": [
+      "./*",
+      "./*.d.ts"
+    ]
+  },
+  "typesVersions": {
+    "<=4.9": {
+      "*": [
+        "./dist/*",
+        "./*"
+      ]
+    }
+  },
+  "scripts": {
+    "build": "tsup && tsx ../../scripts/postbuild.mts",
+    "dev": "DEV=1 tsup"
+  },
+  "dependencies": {
+    "@vue-macros/common": "workspace:~",
+    "unplugin": "^1.0.1"
+  },
+  "devDependencies": {
+    "rollup": "^3.10.1"
+  },
+  "engines": {
+    "node": ">=16.14.0"
+  }
+}

--- a/packages/chain-call/package.json
+++ b/packages/chain-call/package.json
@@ -81,7 +81,7 @@
     }
   },
   "scripts": {
-    "build": "tsup && tsx ../../scripts/postbuild.mts",
+    "build": "tsup && tsx ../../scripts/postbuild.ts",
     "dev": "DEV=1 tsup"
   },
   "dependencies": {

--- a/packages/chain-call/src/api.ts
+++ b/packages/chain-call/src/api.ts
@@ -1,0 +1,1 @@
+export * from './core'

--- a/packages/chain-call/src/core/index.ts
+++ b/packages/chain-call/src/core/index.ts
@@ -32,7 +32,8 @@ export function transformChainCall(code: string, id: string) {
   })
 
   function processChainCall(node: CallExpression) {
-    const withDefaultString = s.sliceNode(node.arguments[0], { offset })
+    const withDefaultString: string | undefined =
+      node.arguments[0] && s.sliceNode(node.arguments[0], { offset })
     const definePropsString = s.sliceNode(
       (node.callee as MemberExpression).object as CallExpression,
       { offset }
@@ -40,7 +41,9 @@ export function transformChainCall(code: string, id: string) {
 
     s.overwriteNode(
       node,
-      `${WITH_DEFAULTS}(${definePropsString}, ${withDefaultString})`,
+      withDefaultString
+        ? `${WITH_DEFAULTS}(${definePropsString}, ${withDefaultString})`
+        : definePropsString,
       { offset }
     )
   }

--- a/packages/chain-call/src/core/index.ts
+++ b/packages/chain-call/src/core/index.ts
@@ -1,0 +1,59 @@
+import {
+  DEFINE_PROPS,
+  MagicString,
+  WITH_DEFAULTS,
+  getTransformResult,
+  isCallOf,
+  isIdentifierOf,
+  parseSFC,
+  removeMacroImport,
+  walkAST,
+} from '@vue-macros/common'
+import {
+  type CallExpression,
+  type MemberExpression,
+  type Node,
+} from '@babel/types'
+
+export function transformChainCall(code: string, id: string) {
+  if (!code.includes(DEFINE_PROPS)) return
+
+  const { scriptSetup, getSetupAst, offset } = parseSFC(code, id)
+  if (!scriptSetup) return
+
+  const s = new MagicString(code)
+  const setupAst = getSetupAst()!
+
+  walkAST<Node>(setupAst, {
+    enter(node) {
+      if (removeMacroImport(node, s, offset)) return
+      if (isChainCall(node)) processChainCall(node)
+    },
+  })
+
+  function processChainCall(node: CallExpression) {
+    const withDefaultString = s.sliceNode(node.arguments[0], { offset })
+    const definePropsString = s.sliceNode(
+      (node.callee as MemberExpression).object as CallExpression,
+      { offset }
+    )
+
+    s.overwriteNode(
+      node,
+      `${WITH_DEFAULTS}(${definePropsString}, ${withDefaultString})`,
+      { offset }
+    )
+  }
+
+  return getTransformResult(s, id)
+}
+
+function isChainCall(node: Node): node is CallExpression {
+  // defineProps().withDefaults()
+  return (
+    node.type === 'CallExpression' &&
+    node.callee.type === 'MemberExpression' &&
+    isCallOf(node.callee.object, DEFINE_PROPS) &&
+    isIdentifierOf(node.callee.property, WITH_DEFAULTS)
+  )
+}

--- a/packages/chain-call/src/esbuild.ts
+++ b/packages/chain-call/src/esbuild.ts
@@ -1,0 +1,3 @@
+import unplugin from '.'
+
+export default unplugin.esbuild

--- a/packages/chain-call/src/index.ts
+++ b/packages/chain-call/src/index.ts
@@ -1,5 +1,7 @@
 import { createUnplugin } from 'unplugin'
 import {
+  type BaseOptions,
+  type MarkRequired,
   REGEX_SETUP_SFC,
   REGEX_VUE_SFC,
   REGEX_VUE_SUB,
@@ -7,21 +9,14 @@ import {
   detectVueVersion,
 } from '@vue-macros/common'
 import { transformChainCall } from './core'
-import type { UnpluginContextMeta } from 'unplugin'
-import type { BaseOptions, MarkRequired } from '@vue-macros/common'
 
 export type Options = BaseOptions
 export type OptionsResolved = MarkRequired<Options, 'include' | 'version'>
 
-function resolveOption(
-  options: Options,
-  framework: UnpluginContextMeta['framework']
-): OptionsResolved {
+function resolveOption(options: Options): OptionsResolved {
   const version = options.version || detectVueVersion()
   return {
-    include: [REGEX_VUE_SFC, REGEX_SETUP_SFC].concat(
-      version === 2 && framework === 'webpack' ? REGEX_VUE_SUB : []
-    ),
+    include: [REGEX_VUE_SFC, REGEX_SETUP_SFC, REGEX_VUE_SUB],
     ...options,
     version,
   }
@@ -30,8 +25,8 @@ function resolveOption(
 const name = 'unplugin-vue-chain-call'
 
 export default createUnplugin<Options | undefined, false>(
-  (userOptions = {}, { framework }) => {
-    const options = resolveOption(userOptions, framework)
+  (userOptions = {}) => {
+    const options = resolveOption(userOptions)
     const filter = createFilter(options)
 
     return {

--- a/packages/chain-call/src/index.ts
+++ b/packages/chain-call/src/index.ts
@@ -1,0 +1,50 @@
+import { createUnplugin } from 'unplugin'
+import {
+  REGEX_SETUP_SFC,
+  REGEX_VUE_SFC,
+  REGEX_VUE_SUB,
+  createFilter,
+  detectVueVersion,
+} from '@vue-macros/common'
+import { transformChainCall } from './core'
+import type { UnpluginContextMeta } from 'unplugin'
+import type { BaseOptions, MarkRequired } from '@vue-macros/common'
+
+export type Options = BaseOptions
+export type OptionsResolved = MarkRequired<Options, 'include' | 'version'>
+
+function resolveOption(
+  options: Options,
+  framework: UnpluginContextMeta['framework']
+): OptionsResolved {
+  const version = options.version || detectVueVersion()
+  return {
+    include: [REGEX_VUE_SFC, REGEX_SETUP_SFC].concat(
+      version === 2 && framework === 'webpack' ? REGEX_VUE_SUB : []
+    ),
+    ...options,
+    version,
+  }
+}
+
+const name = 'unplugin-vue-chain-call'
+
+export default createUnplugin<Options | undefined, false>(
+  (userOptions = {}, { framework }) => {
+    const options = resolveOption(userOptions, framework)
+    const filter = createFilter(options)
+
+    return {
+      name,
+      enforce: 'pre',
+
+      transformInclude(id) {
+        return filter(id)
+      },
+
+      transform(code, id) {
+        return transformChainCall(code, id)
+      },
+    }
+  }
+)

--- a/packages/chain-call/src/rollup.ts
+++ b/packages/chain-call/src/rollup.ts
@@ -1,0 +1,3 @@
+import unplugin from '.'
+
+export default unplugin.rollup

--- a/packages/chain-call/src/vite.ts
+++ b/packages/chain-call/src/vite.ts
@@ -1,0 +1,3 @@
+import unplugin from '.'
+
+export default unplugin.vite

--- a/packages/chain-call/src/webpack.ts
+++ b/packages/chain-call/src/webpack.ts
@@ -1,0 +1,3 @@
+import unplugin from '.'
+
+export default unplugin.webpack

--- a/packages/chain-call/tests/__snapshots__/fixtures.test.ts.snap
+++ b/packages/chain-call/tests/__snapshots__/fixtures.test.ts.snap
@@ -76,12 +76,14 @@ export { destruct as default };
 
 exports[`fixtures > tests/fixtures/empty.vue 1`] = `
 "import { defineComponent } from 'vue';
+import { expectTypeOf } from 'expect-type';
 import _export_sfc from '[NULL]/plugin-vue/export-helper';
 
 var _sfc_main = /* @__PURE__ */ defineComponent({
   __name: \\"empty\\",
   setup(__props) {
     const props = __props;
+    expectTypeOf().toEqualTypeOf();
     return () => {
     };
   }
@@ -90,6 +92,30 @@ var _sfc_main = /* @__PURE__ */ defineComponent({
 var empty = /* @__PURE__ */ _export_sfc(_sfc_main, [__FILE__]);
 
 export { empty as default };
+"
+`;
+
+exports[`fixtures > tests/fixtures/empty-defaults.vue 1`] = `
+"import { defineComponent } from 'vue';
+import { expectTypeOf } from 'expect-type';
+import _export_sfc from '[NULL]/plugin-vue/export-helper';
+
+var _sfc_main = /* @__PURE__ */ defineComponent({
+  __name: \\"empty-defaults\\",
+  props: {
+    foo: { type: String, required: false }
+  },
+  setup(__props) {
+    const props = __props;
+    expectTypeOf().toEqualTypeOf();
+    return () => {
+    };
+  }
+});
+
+var emptyDefaults = /* @__PURE__ */ _export_sfc(_sfc_main, [__FILE__]);
+
+export { emptyDefaults as default };
 "
 `;
 

--- a/packages/chain-call/tests/__snapshots__/fixtures.test.ts.snap
+++ b/packages/chain-call/tests/__snapshots__/fixtures.test.ts.snap
@@ -1,0 +1,115 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`fixtures > tests/fixtures/basic.vue 1`] = `
+"import { defineComponent } from 'vue';
+import { expectTypeOf } from 'expect-type';
+import _export_sfc from '[NULL]/plugin-vue/export-helper';
+
+var _sfc_main = /* @__PURE__ */ defineComponent({
+  __name: \\"basic\\",
+  props: {
+    foo: { type: String, required: false, default: \\"111\\" },
+    bar: { type: Number, required: false, default: 111 },
+    baz: { type: Boolean, required: false, default: false }
+  },
+  setup(__props) {
+    const props = __props;
+    expectTypeOf(props).toEqualTypeOf();
+    return () => {
+    };
+  }
+});
+
+var basic = /* @__PURE__ */ _export_sfc(_sfc_main, [__FILE__]);
+
+export { basic as default };
+"
+`;
+
+exports[`fixtures > tests/fixtures/declare.vue 1`] = `
+"import { defineComponent, toDisplayString } from 'vue';
+import { expectTypeOf } from 'expect-type';
+import _export_sfc from '[NULL]/plugin-vue/export-helper';
+
+var _sfc_main = /* @__PURE__ */ defineComponent({
+  __name: \\"declare\\",
+  props: {
+    bar: { type: Boolean, required: false, default: true }
+  },
+  setup(__props) {
+    const props = __props;
+    expectTypeOf(props).toEqualTypeOf();
+    return (_ctx, _cache) => {
+      return toDisplayString(props);
+    };
+  }
+});
+
+var declare = /* @__PURE__ */ _export_sfc(_sfc_main, [__FILE__]);
+
+export { declare as default };
+"
+`;
+
+exports[`fixtures > tests/fixtures/destruct.vue 1`] = `
+"import { defineComponent, openBlock, createElementBlock, toDisplayString } from 'vue';
+import _export_sfc from '[NULL]/plugin-vue/export-helper';
+
+var _sfc_main = /* @__PURE__ */ defineComponent({
+  __name: \\"destruct\\",
+  props: {
+    foo: { type: String, required: false, default: \\"111\\" }
+  },
+  setup(__props) {
+    const { foo } = __props;
+    return (_ctx, _cache) => {
+      return openBlock(), createElementBlock(\\"div\\", null, toDisplayString(foo));
+    };
+  }
+});
+
+var destruct = /* @__PURE__ */ _export_sfc(_sfc_main, [__FILE__]);
+
+export { destruct as default };
+"
+`;
+
+exports[`fixtures > tests/fixtures/empty.vue 1`] = `
+"import { defineComponent } from 'vue';
+import _export_sfc from '[NULL]/plugin-vue/export-helper';
+
+var _sfc_main = /* @__PURE__ */ defineComponent({
+  __name: \\"empty\\",
+  setup(__props) {
+    const props = __props;
+    return () => {
+    };
+  }
+});
+
+var empty = /* @__PURE__ */ _export_sfc(_sfc_main, [__FILE__]);
+
+export { empty as default };
+"
+`;
+
+exports[`fixtures > tests/fixtures/tsx.vue 1`] = `
+"import { defineComponent } from 'vue';
+import _export_sfc from '[NULL]/plugin-vue/export-helper';
+
+var _sfc_main = /* @__PURE__ */ defineComponent({
+  __name: \\"tsx\\",
+  props: {
+    foo: { type: String, required: false, default: \\"111\\" }
+  },
+  setup(__props) {
+    return () => {
+    };
+  }
+});
+
+var tsx = /* @__PURE__ */ _export_sfc(_sfc_main, [__FILE__]);
+
+export { tsx as default };
+"
+`;

--- a/packages/chain-call/tests/fixtures.test.ts
+++ b/packages/chain-call/tests/fixtures.test.ts
@@ -1,0 +1,37 @@
+import { resolve } from 'node:path'
+import { describe } from 'vitest'
+import {
+  RollupEsbuildPlugin,
+  RollupRemoveVueFilePathPlugin,
+  RollupVue,
+  rollupBuild,
+  testFixtures,
+} from '@vue-macros/test-utils'
+import { transformChainCall } from '../src/core'
+import VueChainCall from '../src/rollup'
+
+describe('fixtures', async () => {
+  await testFixtures(
+    ['tests/fixtures/*.vue', '!tests/fixtures/definePropsRefs.vue'],
+    (_, id) =>
+      rollupBuild(id, [
+        VueChainCall(),
+        RollupVue(),
+        RollupRemoveVueFilePathPlugin(),
+        RollupEsbuildPlugin({
+          target: 'esnext',
+        }),
+      ]),
+    {
+      cwd: resolve(__dirname, '..'),
+      promise: true,
+    }
+  )
+  await testFixtures(
+    import.meta.glob('./fixtures/definePropsRefs.vue', {
+      eager: true,
+      as: 'raw',
+    }),
+    (_, id, code) => transformChainCall(code, id)?.code
+  )
+})

--- a/packages/chain-call/tests/fixtures/basic.vue
+++ b/packages/chain-call/tests/fixtures/basic.vue
@@ -1,0 +1,20 @@
+<script setup lang="ts">
+import { expectTypeOf } from 'expect-type';
+import { defineProps } from '../../macros' assert { type: 'macro' }
+
+const props = defineProps<{
+  foo?: string
+  bar?: number
+  baz?: boolean
+}>().withDefaults({
+  foo: '111',
+  bar: 111,
+  baz: false,
+})
+
+expectTypeOf(props).toEqualTypeOf<{
+  foo: string
+  bar: number
+  baz: boolean
+}>()
+</script>

--- a/packages/chain-call/tests/fixtures/declare.vue
+++ b/packages/chain-call/tests/fixtures/declare.vue
@@ -1,0 +1,17 @@
+<script setup lang="ts">
+import { expectTypeOf } from 'expect-type'
+import { defineProps } from '../../macros' assert { type: 'macro' }
+
+const props = defineProps<{
+  bar?: boolean
+}>().withDefaults({
+  bar: true,
+})
+expectTypeOf(props).toEqualTypeOf<{
+  bar: boolean
+}>()
+</script>
+
+<template>
+  {{ props }}
+</template>

--- a/packages/chain-call/tests/fixtures/destruct.vue
+++ b/packages/chain-call/tests/fixtures/destruct.vue
@@ -1,0 +1,12 @@
+<script setup lang="ts">
+import { defineProps } from '../../macros' assert { type: 'macro' }
+
+const { foo } = defineProps<{
+  foo?: string
+}>().withDefaults({
+  foo: '111',
+})
+</script>
+<template>
+  <div>{{ foo }}</div>
+</template>

--- a/packages/chain-call/tests/fixtures/empty-defaults.vue
+++ b/packages/chain-call/tests/fixtures/empty-defaults.vue
@@ -2,6 +2,11 @@
 import { expectTypeOf } from 'expect-type'
 import { Prettify, defineProps } from '../../macros' assert { type: 'macro' }
 
-const props = defineProps().withDefaults({})
-expectTypeOf<Prettify<typeof props>>().toEqualTypeOf<{}>()
+const props = defineProps<{
+  foo?: string
+}>().withDefaults()
+
+expectTypeOf<Prettify<typeof props>>().toEqualTypeOf<{
+  readonly foo?: string
+}>()
 </script>

--- a/packages/chain-call/tests/fixtures/empty.vue
+++ b/packages/chain-call/tests/fixtures/empty.vue
@@ -1,0 +1,5 @@
+<script setup lang="ts">
+import { defineProps } from '../../macros' assert { type: 'macro' }
+
+const props = defineProps().withDefaults({})
+</script>

--- a/packages/chain-call/tests/fixtures/tsx.vue
+++ b/packages/chain-call/tests/fixtures/tsx.vue
@@ -1,0 +1,9 @@
+<script setup lang="tsx">
+import { defineProps } from '../../macros' assert { type: 'macro' }
+
+defineProps<{
+  foo?: string
+}>().withDefaults({
+  foo: '111'
+})
+</script>

--- a/packages/chain-call/tsup.config.ts
+++ b/packages/chain-call/tsup.config.ts
@@ -1,0 +1,1 @@
+export { default } from '../../tsup.config.js'

--- a/packages/chain-call/vue2-macros.d.ts
+++ b/packages/chain-call/vue2-macros.d.ts
@@ -1,0 +1,66 @@
+import { type ExtractPropTypes } from 'vue'
+import { type ComponentObjectPropsOptions } from 'vue/types/v3-component-props'
+
+// copy from vue-core
+export type Prettify<T> = {
+  [K in keyof T]: T[K]
+} & {}
+
+type NotUndefined<T> = T extends undefined ? never : T
+type InferDefaults<T> = {
+  [K in keyof T]?: InferDefault<T, T[K]>
+}
+type NativeType = null | number | string | boolean | symbol | Function
+type InferDefault<P, T> =
+  | ((props: P) => T & {})
+  | (T extends NativeType ? T : never)
+type PropsWithDefaults<
+  T,
+  Defaults extends InferDefaults<T>,
+  BKeys extends keyof T
+> = Omit<T, keyof Defaults> & {
+  [K in keyof Defaults]-?: K extends keyof T
+    ? Defaults[K] extends undefined
+      ? T[K]
+      : NotUndefined<T[K]>
+    : never
+} & {
+  readonly [K in BKeys]-?: boolean
+}
+type DefineProps<T, BKeys extends keyof T> = Readonly<T> & {
+  readonly [K in BKeys]-?: boolean
+}
+type BooleanKey<T, K extends keyof T = keyof T> = K extends any
+  ? [T[K]] extends [boolean | undefined]
+    ? K
+    : never
+  : never
+
+// end
+
+export type AttachWithDefaults<Props> = Props & {
+  withDefaults(): Props
+  withDefaults<
+    BKeys extends BooleanKey<Props>,
+    Defaults extends InferDefaults<Props>
+  >(
+    defaults?: Defaults
+  ): Prettify<PropsWithDefaults<Props, Defaults, BKeys>>
+}
+
+export declare function defineProps<PropNames extends string = string>(
+  props: PropNames[]
+): Prettify<
+  AttachWithDefaults<
+    Readonly<{
+      [key in PropNames]?: any
+    }>
+  >
+>
+export declare function defineProps<
+  PP extends ComponentObjectPropsOptions = ComponentObjectPropsOptions
+>(props: PP): Prettify<AttachWithDefaults<Readonly<ExtractPropTypes<PP>>>>
+
+export declare function defineProps<TypeProps>(): AttachWithDefaults<
+  DefineProps<TypeProps, BooleanKey<TypeProps>>
+>

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -54,7 +54,7 @@
     "@babel/types": "^7.22.4",
     "@rollup/pluginutils": "^5.0.2",
     "@vue/compiler-sfc": "^3.3.4",
-    "ast-kit": "^0.5.2",
+    "ast-kit": "^0.6.2",
     "local-pkg": "^0.4.3",
     "magic-string-ast": "^0.1.2"
   },

--- a/packages/common/src/vue.ts
+++ b/packages/common/src/vue.ts
@@ -21,6 +21,7 @@ export type SFC = Omit<SFCDescriptor, 'script' | 'scriptSetup'> & {
   lang: string | undefined
   getScriptAst(): Program | undefined
   getSetupAst(): Program | undefined
+  offset: number
 } & Pick<SFCParseResult, 'errors'>
 
 export function parseSFC(code: string, id: string): SFC {
@@ -49,6 +50,7 @@ export function parseSFC(code: string, id: string): SFC {
     ...descriptor,
     lang,
     errors,
+    offset: descriptor.scriptSetup?.loc.start.offset ?? 0,
     getSetupAst() {
       if (!descriptor.scriptSetup) return
       return babelParse(descriptor.scriptSetup.content, lang, {
@@ -108,6 +110,8 @@ export function removeMacroImport(node: Node, s: MagicString, offset: number) {
       (attr) =>
         resolveString(attr.key) === 'type' && attr.value.value === 'macro'
     )
-  )
+  ) {
     s.removeNode(node, { offset })
+    return true
+  }
 }

--- a/packages/define-props-refs/macros-global.d.ts
+++ b/packages/define-props-refs/macros-global.d.ts
@@ -1,2 +1,1 @@
-// @ts-ignore
 declare const definePropsRefs: typeof import('./macros').definePropsRefs

--- a/packages/define-props-refs/macros-global.d.ts
+++ b/packages/define-props-refs/macros-global.d.ts
@@ -1,1 +1,2 @@
+// @ts-ignore
 declare const definePropsRefs: typeof import('./macros').definePropsRefs

--- a/packages/define-props-refs/tests/__snapshots__/fixtures.test.ts.snap
+++ b/packages/define-props-refs/tests/__snapshots__/fixtures.test.ts.snap
@@ -32,7 +32,6 @@ const __MACROS_props = withDefaults(defineProps<{
 import { toRefs as __MACROS_toRefs } from \\"vue\\";
 import { expectTypeOf } from 'expect-type'
 import { ComputedRef } from 'vue'
-import { withDefaults, definePropsRefs } from '../../macros'
 
 
 const { foo, bar } = __MACROS_toRefs(__MACROS_props)

--- a/packages/define-props-refs/tests/__snapshots__/fixtures.test.ts.snap
+++ b/packages/define-props-refs/tests/__snapshots__/fixtures.test.ts.snap
@@ -32,6 +32,7 @@ const __MACROS_props = withDefaults(defineProps<{
 import { toRefs as __MACROS_toRefs } from \\"vue\\";
 import { expectTypeOf } from 'expect-type'
 import { ComputedRef } from 'vue'
+import { withDefaults, definePropsRefs } from '../../macros'
 
 
 const { foo, bar } = __MACROS_toRefs(__MACROS_props)

--- a/packages/define-props-refs/vue2-macros.d.ts
+++ b/packages/define-props-refs/vue2-macros.d.ts
@@ -6,8 +6,6 @@ import {
   type Ref,
 } from 'vue'
 
-import {} from 'vue/types/v3-setup-context'
-
 export declare type PropRefs<T> = {
   [K in keyof T]-?: ComputedRef<DeepReadonly<T[K]>>
 }

--- a/packages/macros/macros.d.ts
+++ b/packages/macros/macros.d.ts
@@ -1,3 +1,4 @@
+import { type defineProps as definePropsChainCall } from '@vue-macros/chain-call/macros'
 import {
   definePropsRefs,
   type withDefaults as withDefaultsDefinePropsRefs,
@@ -22,6 +23,11 @@ export { definePropsRefs }
 interface WithDefaultsMap {
   definePropsRefs: typeof withDefaultsDefinePropsRefs
 }
-
 type WithDefaults = UnionToIntersection<RecordToUnion<WithDefaultsMap>>
 export declare const withDefaults: WithDefaults
+
+interface DefinePropsMap {
+  chainCall: typeof definePropsChainCall
+}
+type DefineProps = UnionToIntersection<RecordToUnion<DefinePropsMap>>
+export declare const defineProps: DefineProps

--- a/packages/macros/package.json
+++ b/packages/macros/package.json
@@ -84,6 +84,7 @@
   },
   "dependencies": {
     "@vue-macros/better-define": "workspace:*",
+    "@vue-macros/chain-call": "workspace:^",
     "@vue-macros/common": "workspace:*",
     "@vue-macros/define-emit": "workspace:^",
     "@vue-macros/define-models": "workspace:*",

--- a/packages/macros/src/index.ts
+++ b/packages/macros/src/index.ts
@@ -12,6 +12,9 @@ import { Devtools } from '@vue-macros/devtools'
 import VueBetterDefine, {
   type Options as OptionsBetterDefine,
 } from '@vue-macros/better-define'
+import VueChainCall, {
+  type Options as OptionsChainCall,
+} from '@vue-macros/chain-call'
 import VueDefineEmit, {
   type Options as OptionsDefineEmit,
 } from '@vue-macros/define-emit'
@@ -66,6 +69,7 @@ import VueShortEmits, {
 
 export interface FeatureOptionsMap {
   betterDefine: OptionsBetterDefine
+  chainCall: OptionsChainCall
   defineEmit: OptionsDefineEmit
   defineModels: OptionsDefineModels
   defineOptions: OptionsDefineOptions
@@ -119,6 +123,7 @@ export function resolveOptions({
   nuxtContext,
 
   betterDefine,
+  chainCall,
   defineEmit,
   defineModels,
   defineOptions,
@@ -164,6 +169,7 @@ export function resolveOptions({
       version,
       isProduction,
     }),
+    chainCall: resolveSubOptions<'chainCall'>(chainCall, { version }),
     defineEmit: resolveSubOptions<'defineEmit'>(defineEmit, {
       isProduction,
       version,
@@ -268,6 +274,7 @@ export default createCombinePlugin<Options | undefined>(
       resolvePlugin(VueDefineEmit, framework, options.defineEmit),
       resolvePlugin(VueDefineProps, framework, options.defineProps),
       resolvePlugin(VueDefinePropsRefs, framework, options.definePropsRefs),
+      resolvePlugin(VueChainCall, framework, options.chainCall),
       resolvePlugin(VueExportProps, framework, options.exportProps),
       resolvePlugin(VueShortEmits, framework, options.shortEmits),
       resolvePlugin(VueDefineModels, framework, options.defineModels),

--- a/packages/macros/vue2-macros.d.ts
+++ b/packages/macros/vue2-macros.d.ts
@@ -1,3 +1,4 @@
+import { type defineProps as definePropsChainCall } from '@vue-macros/chain-call/vue2-macros'
 import {
   definePropsRefs,
   type withDefaults as withDefaultsDefinePropsRefs,
@@ -21,6 +22,11 @@ export { definePropsRefs }
 interface WithDefaultsMap {
   definePropsRefs: typeof withDefaultsDefinePropsRefs
 }
-
 type WithDefaults = UnionToIntersection<RecordToUnion<WithDefaultsMap>>
 export declare const withDefaults: WithDefaults
+
+interface DefinePropsMap {
+  chainCall: typeof definePropsChainCall
+}
+type DefineProps = UnionToIntersection<RecordToUnion<DefinePropsMap>>
+export declare const defineProps: DefineProps

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -395,6 +395,9 @@ importers:
       '@vue-macros/better-define':
         specifier: workspace:*
         version: link:../better-define
+      '@vue-macros/chain-call':
+        specifier: workspace:^
+        version: link:../chain-call
       '@vue-macros/common':
         specifier: workspace:*
         version: link:../common

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -149,6 +149,19 @@ importers:
         specifier: ^3.23.1
         version: 3.23.1
 
+  packages/chain-call:
+    dependencies:
+      '@vue-macros/common':
+        specifier: workspace:~
+        version: link:../common
+      unplugin:
+        specifier: ^1.0.1
+        version: 1.3.1
+    devDependencies:
+      rollup:
+        specifier: ^3.10.1
+        version: 3.23.1
+
   packages/common:
     dependencies:
       '@babel/types':
@@ -161,8 +174,8 @@ importers:
         specifier: ^3.3.4
         version: 3.3.4
       ast-kit:
-        specifier: ^0.5.2
-        version: 0.5.2
+        specifier: ^0.6.2
+        version: 0.6.2
       local-pkg:
         specifier: ^0.4.3
         version: 0.4.3
@@ -4392,8 +4405,8 @@ packages:
     resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
     dev: true
 
-  /ast-kit@0.5.2:
-    resolution: {integrity: sha512-WxA0dveHJ0MB0YemuFNR859FCpAblh0Y5x2g0ma8+NZMm/MeScrltEcP1dC8dfaBkJDDcBEUmJvf+LJDq/G2UQ==}
+  /ast-kit@0.6.2:
+    resolution: {integrity: sha512-H0BqU5HXa9bR8G4wHyAOJGMihn9eBJYUi5ZloNZOVsvHeGtAoFk3hxHftsfwcpZz24X7zBNQl3QM1ZluzoKqhA==}
     engines: {node: '>=16.14.0'}
     dependencies:
       '@babel/parser': 7.22.4


### PR DESCRIPTION
### Description

Extends `defineProps`, support call `withDefaults` as a chain:

```vue
<script setup lang="ts">
import { defineProps } from 'unplugin-vue-macros/macros' assert { type: 'macro' }

const { foo } = defineProps<{
  foo?: string
}>().withDefaults({
  foo: '111',
})
</script>
<template></template>
```

will compiles to

```vue
<script setup lang="ts">
const { foo } = withDefaults(defineProps<{
  foo?: string
}>(), {
  foo: '111'
})
</script>
<template></template>
```
### Linked Issues

closes #214 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
